### PR TITLE
Add `columns_to_keep` to fix dataset loading issue

### DIFF
--- a/train/scripts/run_sft.py
+++ b/train/scripts/run_sft.py
@@ -194,7 +194,11 @@ def main():
     ###############
     # Load datasets
     ###############
-    raw_datasets = get_datasets(data_args, splits=data_args.dataset_splits)
+    raw_datasets = get_datasets(
+        data_args, 
+        splits=data_args.dataset_splits,
+        columns_to_keep=['instruction', 'output', 'input', 'messages'],
+    )
     logger.info(
         f"Training on the following datasets and their proportions: {[split + ' : ' + str(dset.num_rows) for split, dset in raw_datasets.items()]}"
     )


### PR DESCRIPTION
### Description
When loading dataset to train, the package `alignment` returns none since columns_to_keep is set to None as default([git](https://github.com/huggingface/alignment-handbook/blob/606d2e954fd17999af40e6fb4f712055ca11b2f0/src/alignment/data.py#L125)).
So I'm suggesting to pass `columns_to_keep` as an argument to fix this issue.
 
### Package Info
- alignment-handbook: 0.4.0.dev0

Thanks for the great work!